### PR TITLE
fix key name in from_json for input/setup errors

### DIFF
--- a/panther_core/exec/results.py
+++ b/panther_core/exec/results.py
@@ -123,8 +123,8 @@ class ExecutionDetails(_BaseDataObject):
     @classmethod
     def from_json(cls, data: Dict[str, any]):
         return cls(
-            input_error=data.get('input_exception'),
-            setup_error=data.get('setup_exception'),
+            input_error=data.get('input_error'),
+            setup_error=data.get('setup_error'),
             aux_functions=ExecutionDetailsAuxFunctions.from_json(data['aux_functions']),
             primary_functions=ExecutionDetailsPrimaryFunctions.from_json(data['primary_functions']),
         )

--- a/tests/unit/panther_core/test_exec_serialization.py
+++ b/tests/unit/panther_core/test_exec_serialization.py
@@ -165,7 +165,9 @@ class TestSerialization(unittest.TestCase):
                                 error=None,
                                 output=False,
                             ),
-                        )
+                        ),
+                        setup_error="boop",
+                        input_error="boop"
                     )
                 )
             ]


### PR DESCRIPTION
### Background

`from_json` was using the wrong keys for input/setup errors

### Changes

* changed keys from `*_exception` to `*_error`

### Testing

* updated unit test
