### PR TITLE
ExecutionTask takes only one data model

### DIFF
--- a/panther_core/exec/common.py
+++ b/panther_core/exec/common.py
@@ -67,7 +67,9 @@ class ExecutionMatch:
 
     @classmethod
     def from_json(cls, data: Dict[str, any]):
-        return cls(**data)
+        if data is not None:
+            return cls(**data)
+        return None
 
 @dataclass(frozen=True)
 class _BaseDataObject:

--- a/panther_core/exec/task.py
+++ b/panther_core/exec/task.py
@@ -104,7 +104,7 @@ class ExecutionEnv(_BaseDataObject):
     outputs: List[ExecutionEnvComponent]
     globals: List[ExecutionEnvComponent]
     detections: List[ExecutionEnvComponent]
-    data_models: List[ExecutionEnvComponent]
+    data_model: Optional[ExecutionEnvComponent]
 
     @classmethod
     def from_json(cls, data: Dict[str, any]):
@@ -113,7 +113,7 @@ class ExecutionEnv(_BaseDataObject):
             outputs=data.get('outputs', []),
             globals=data.get('globals', []),
             detections=data.get('detections', []),
-            data_models=data.get('data_models', []),
+            data_model=data.get('data_models', None),
         )
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,14 +22,14 @@ setup(
     name='panther_core',
     packages=['panther_core', 'panther_core/exec'],
     package_dir={'exec': 'panther_core/exec'},
-    version='0.0.6',
+    version='0.0.7',
     license='AGPL-3.0',
     description=
     'Panther command line interface for writing, testing, and packaging policies/rules.',
     author='Panther Labs Inc',
     author_email='pypi@runpanther.io',
     url='https://github.com/panther-labs/panther_core',
-    download_url = 'https://github.com/panther-labs/panther_core/archive/v0.0.6.tar.gz',
+    download_url = 'https://github.com/panther-labs/panther_core/archive/v0.0.7.tar.gz',
     keywords=['Security', 'CLI'],
     install_requires=install_requires,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -22,14 +22,14 @@ setup(
     name='panther_core',
     packages=['panther_core', 'panther_core/exec'],
     package_dir={'exec': 'panther_core/exec'},
-    version='0.0.7',
+    version='0.0.8',
     license='AGPL-3.0',
     description=
     'Panther command line interface for writing, testing, and packaging policies/rules.',
     author='Panther Labs Inc',
     author_email='pypi@runpanther.io',
     url='https://github.com/panther-labs/panther_core',
-    download_url = 'https://github.com/panther-labs/panther_core/archive/v0.0.7.tar.gz',
+    download_url = 'https://github.com/panther-labs/panther_core/archive/v0.0.8.tar.gz',
     keywords=['Security', 'CLI'],
     install_requires=install_requires,
     classifiers=[

--- a/tests/unit/panther_core/test_exec_serialization.py
+++ b/tests/unit/panther_core/test_exec_serialization.py
@@ -77,7 +77,7 @@ class TestSerialization(unittest.TestCase):
                     outputs=[dict(id="b")],
                     globals=[dict(id="a")],
                     detections=[dict(id="b")],
-                    data_models=[],
+                    data_model=None,
                 )
             ),
             input=ExecutionTaskInput(


### PR DESCRIPTION
### Background

ExecutionTask used to take a list of Data Models.  We only need one.